### PR TITLE
ENA: fix missing float to int conversion

### DIFF
--- a/exopy_qcircuits/instruments/drivers/visa/keysight_ena.py
+++ b/exopy_qcircuits/instruments/drivers/visa/keysight_ena.py
@@ -587,7 +587,7 @@ class KeysightENAChannel(BaseInstrument):
         points = self._pna.ask_for_values('SENSe{}:SWEep:POINts?'.format(
                                           self._channel))
         if points:
-            return points[0]
+            return int(points[0])
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} sweep point number'''.format(self._channel)))


### PR DESCRIPTION
Fixes a small bug that can sometimes occur when trying to pull a sweep from the ENA.
Was tested on real hardware.