### PR TITLE
Fix keysight_ena (Exopy/exopy_hqc_legacy@9fa16bd)

### DIFF
--- a/exopy_qcircuits/instruments/drivers/visa/keysight_ena.py
+++ b/exopy_qcircuits/instruments/drivers/visa/keysight_ena.py
@@ -98,8 +98,8 @@ class KeysightENAChannel(BaseInstrument):
         else:
             data = self._pna.query_ascii_values(data_request)
 
-        if data:
-            return np.array(data)
+        if data.size:
+            return data
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                 channel {} formatted data for meas {}'''.format(
@@ -132,9 +132,8 @@ class KeysightENAChannel(BaseInstrument):
         else:
             data = self._pna.query_ascii_values(data_request)
 
-        if data:
-            aux = np.array(data)
-            return aux[::2] + 1j*aux[1::2]
+        if data.size:
+            return data[::2] + 1j*data[1::2]
         else:
             raise InstrIOError(cleandoc('''Keysight ENA did not return the
                 channel {} formatted data for trace {}'''.format(


### PR DESCRIPTION
Exopy/exopy_hqc_legacy@9fa16bd enforced `np.ndarray` outputs by default in `query_binary_values` and `query_ascii_values`, while `read_raw_data` and `read_formatted_data` in `keysight_ena.py` still expect a `list` instead of an `np.ndarray`. This is fixed by this PR.